### PR TITLE
Add unittest for email ValueObject

### DIFF
--- a/test/Shopway.Tests.Unit/LayerTests/Domain/ValueObjects/EmailTests.cs
+++ b/test/Shopway.Tests.Unit/LayerTests/Domain/ValueObjects/EmailTests.cs
@@ -1,0 +1,40 @@
+﻿using Shopway.Domain.Errors;
+using Shopway.Domain.ValueObjects;
+using Shopway.Tests.Unit.Abstractions;
+using Shopway.Tests.Unit.Constants;
+using static Shopway.Domain.Errors.Domain.DomainErrors;
+
+namespace Shopway.Tests.Unit.LayerTests.Domain.ValueObjects;
+
+public sealed class EmailTests : TestBase
+{
+    private sealed class InvalidEmailTestData : TheoryData<string, Error[]>
+    {
+        public InvalidEmailTestData()
+        {
+            var tooLongProductName = TestString(1000);
+            Add(tooLongProductName, new[] { EmailError.TooLong, EmailError.Invalid });
+
+            string emptyProductName = string.Empty;
+            Add(emptyProductName, new[] { EmailError.Empty, EmailError.Invalid });
+
+            string whitespaceProductName = "    ";
+            Add(whitespaceProductName, new[] { EmailError.Empty, EmailError.Invalid });
+        }
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidEmailTestData))]
+    [Trait(TraitConstants.Category, TraitConstants.Domain)]
+    public void Email_ShouldNotCreate_WhenInvalidInput(string invalidEmail, Error[] exceptedError)
+    {
+        //Act
+        var firstName = Email.Create(invalidEmail);
+
+        //Assert
+        firstName.IsFailure.Should().BeTrue();
+        firstName.Error.Should().Be(Error.ValidationError);
+        firstName.ValidationErrors.Should().HaveCount(2);
+        firstName.ValidationErrors.Should().Contain(exceptedError);
+    }
+}

--- a/test/Shopway.Tests.Unit/LayerTests/Domain/ValueObjects/FirstNameTests.cs
+++ b/test/Shopway.Tests.Unit/LayerTests/Domain/ValueObjects/FirstNameTests.cs
@@ -1,6 +1,7 @@
 ﻿using Shopway.Domain.Errors;
 using Shopway.Domain.ValueObjects;
 using Shopway.Tests.Unit.Abstractions;
+using Shopway.Tests.Unit.Constants;
 using static Shopway.Domain.Errors.Domain.DomainErrors;
 
 namespace Shopway.Tests.Unit.LayerTests.Domain.ValueObjects;
@@ -28,10 +29,13 @@ public sealed class FirstNameTests : TestBase
 
     [Theory]
     [ClassData(typeof(InvalidFirstNameTestData))]
+    [Trait(TraitConstants.Category, TraitConstants.Domain)]
     public void FirstName_ShouldNotCreate_WhenInvalidInput(string invalidFirstName, Error exceptedError)
     {
+        //Act
         var firstName = FirstName.Create(invalidFirstName);
 
+        //Assert
         firstName.IsFailure.Should().BeTrue();
         firstName.Error.Should().Be(Error.ValidationError);
         firstName.ValidationErrors.Should().HaveCount(1);


### PR DESCRIPTION
```cs
public ValidationResult
{
   public Error[] ValidationErrors { get; }
}
```
https://github.com/dr-marek-jaskula/DomainDrivenDesignUniversity/blob/master/src/Shopway.Domain/Results/ValidationResult.cs#L20

ValidationResult can have multiple Errors.
so Email ValueObject is a good example for unit test.