### PR TITLE
Remove unnecessary public keyword in interface definition

### DIFF
--- a/src/Shopway.Application/Abstractions/IDateTimeProvider.cs
+++ b/src/Shopway.Application/Abstractions/IDateTimeProvider.cs
@@ -3,5 +3,5 @@
 //This will be hard to use in interceptors
 public interface IDateTimeProvider
 {
-    public DateTimeOffset UtcNow { get; }
+    DateTimeOffset UtcNow { get; }
 }

--- a/src/Shopway.Domain/Abstractions/Common/IPage.cs
+++ b/src/Shopway.Domain/Abstractions/Common/IPage.cs
@@ -2,6 +2,6 @@
 
 public interface IPage
 {
-    public int PageSize { get; init; }
-    public int PageNumber { get; init; }
+    int PageSize { get; init; }
+    int PageNumber { get; init; }
 }

--- a/src/Shopway.Domain/Abstractions/IDomainEvent.cs
+++ b/src/Shopway.Domain/Abstractions/IDomainEvent.cs
@@ -4,5 +4,5 @@ namespace Shopway.Domain.Abstractions;
 
 public interface IDomainEvent : INotification
 {
-    public Guid Id { get; init; }
+    Guid Id { get; init; }
 }

--- a/src/Shopway.Domain/Abstractions/IEntityId.cs
+++ b/src/Shopway.Domain/Abstractions/IEntityId.cs
@@ -9,16 +9,16 @@ public interface IEntityId<out TEntityId> : IEntityId
     /// <summary>
     /// Create a new entity id using given guid
     /// </summary>
-    public abstract static TEntityId Create(Guid id);
+    abstract static TEntityId Create(Guid id);
 
     /// <summary>
     /// Create a new entity id using randomly generated guid
     /// </summary>
-    public abstract static TEntityId New();
+    abstract static TEntityId New();
 }
 
 public interface IEntityId
 {
-    public const string Id =  nameof(Id);
-    public Guid Value { get; init; }
+    const string Id =  nameof(Id);
+    Guid Value { get; init; }
 }

--- a/src/Shopway.Persistence/Abstractions/IUnitOfWork.cs
+++ b/src/Shopway.Persistence/Abstractions/IUnitOfWork.cs
@@ -6,7 +6,7 @@ namespace Shopway.Persistence.Abstractions;
 public interface IUnitOfWork<TContext>
     where TContext : DbContext
 {
-    public TContext Context { get; }
+    TContext Context { get; }
     Task SaveChangesAsync(CancellationToken cancellationToken);
     Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken);
     IExecutionStrategy CreateExecutionStrategy();

--- a/src/Shopway.Persistence/Abstractions/IUserContextService.cs
+++ b/src/Shopway.Persistence/Abstractions/IUserContextService.cs
@@ -5,8 +5,8 @@ namespace Shopway.Persistence.Abstractions;
 
 public interface IUserContextService
 {
-    public ClaimsPrincipal? User { get; }
-    public UserId? UserId { get; }
-    public CustomerId? CustomerId { get; }
-    public string? Username { get; }
+    ClaimsPrincipal? User { get; }
+    UserId? UserId { get; }
+    CustomerId? CustomerId { get; }
+    string? Username { get; }
 }


### PR DESCRIPTION
## Before
```cs
public interface IDateTimeProvider
{
    public DateTimeOffset UtcNow { get; }
    DateTimeOffset UtcNow { get; }
}
```
~~public~~

## After
```cs
public interface IDateTimeProvider
{
    DateTimeOffset UtcNow { get; }
    DateTimeOffset UtcNow { get; }
}
```

I think it seems like a good idea to remove the explicit public keyword from the interface definition.
