### PR TITLE
refactor: Change the Registration classes access modifier from public to internal

### DIFF
--- a/src/Shopway.Application/Registration/FluentValidationRegistration.cs
+++ b/src/Shopway.Application/Registration/FluentValidationRegistration.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class FluentValidationRegistration
+internal static class FluentValidationRegistration
 {
     internal static IServiceCollection RegisterFluentValidation(this IServiceCollection services)
     {

--- a/src/Shopway.Application/Registration/MiddlewareRegistration.cs
+++ b/src/Shopway.Application/Registration/MiddlewareRegistration.cs
@@ -3,7 +3,7 @@ using Shopway.Application.Middlewares;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class MiddlewaresRegistration
+internal static class MiddlewaresRegistration
 {
     internal static IServiceCollection RegisterMiddlewares(this IServiceCollection services)
     {

--- a/src/Shopway.Infrastructure/Registration/DecoratorRegistration.cs
+++ b/src/Shopway.Infrastructure/Registration/DecoratorRegistration.cs
@@ -3,7 +3,7 @@ using Shopway.Infrastructure.Decoratos;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class DecoratorRegistration
+internal static class DecoratorRegistration
 {
     internal static IServiceCollection RegisterDecorators(this IServiceCollection services)
     {

--- a/src/Shopway.Infrastructure/Registration/FuzzySearchRegistration.cs
+++ b/src/Shopway.Infrastructure/Registration/FuzzySearchRegistration.cs
@@ -3,7 +3,7 @@ using Shopway.Infrastructure.FuzzySearch;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class FuzzySearchRegistration
+internal static class FuzzySearchRegistration
 {
     internal static IServiceCollection RegisterFuzzySearch(this IServiceCollection services)
     {

--- a/src/Shopway.Infrastructure/Registration/OptionsRegistration.cs
+++ b/src/Shopway.Infrastructure/Registration/OptionsRegistration.cs
@@ -4,7 +4,7 @@ using Shopway.Infrastructure.Validators;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class OptionsRegistration
+internal static class OptionsRegistration
 {
     internal static IServiceCollection RegisterOptions(this IServiceCollection services)
     {

--- a/src/Shopway.Infrastructure/Registration/PaymentGatewayRegistration.cs
+++ b/src/Shopway.Infrastructure/Registration/PaymentGatewayRegistration.cs
@@ -6,7 +6,7 @@ using Shopway.Infrastructure.Payments.DummyGatewayTypes;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class PaymentGatewayRegistration
+internal static class PaymentGatewayRegistration
 {
     internal static IServiceCollection RegisterPaymentGateway(this IServiceCollection services)
     {

--- a/src/Shopway.Infrastructure/Registration/ServiceRegistration.cs
+++ b/src/Shopway.Infrastructure/Registration/ServiceRegistration.cs
@@ -9,7 +9,7 @@ using Shopway.Infrastructure.Validators;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class ServiceRegistration
+internal static class ServiceRegistration
 {
     internal static IServiceCollection RegisterServices(this IServiceCollection services)
     {

--- a/src/Shopway.Persistence/Registration/BackgroundServiceRegistration.cs
+++ b/src/Shopway.Persistence/Registration/BackgroundServiceRegistration.cs
@@ -4,7 +4,7 @@ using Shopway.Persistence.Options;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class BackgroundServiceRegistration
+internal static class BackgroundServiceRegistration
 {
     internal static IServiceCollection RegisterBackgroundServices(this IServiceCollection services)
     {

--- a/src/Shopway.Persistence/Registration/CacheRegistration.cs
+++ b/src/Shopway.Persistence/Registration/CacheRegistration.cs
@@ -5,7 +5,7 @@ using ZiggyCreatures.Caching.Fusion.Serialization.NewtonsoftJson;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class CacheRegistration
+internal static class CacheRegistration
 {
     private const string localhost = nameof(localhost);
 

--- a/src/Shopway.Persistence/Registration/DatabaseContextRegistration.cs
+++ b/src/Shopway.Persistence/Registration/DatabaseContextRegistration.cs
@@ -7,7 +7,7 @@ using Shopway.Persistence.Framework;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class DatabaseContextRegistration
+internal static class DatabaseContextRegistration
 {
     internal static IServiceCollection RegisterDatabaseContext(this IServiceCollection services, bool isDevelopment)
     {

--- a/src/Shopway.Persistence/Registration/DecoratorRegistration.cs
+++ b/src/Shopway.Persistence/Registration/DecoratorRegistration.cs
@@ -4,7 +4,7 @@ using Shopway.Persistence.Repositories.Decorators;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class DecoratorRegistration
+internal static class DecoratorRegistration
 {
     internal static IServiceCollection RegisterDecorators(this IServiceCollection services)
     {

--- a/src/Shopway.Persistence/Registration/HealthCheckRegistration.cs
+++ b/src/Shopway.Persistence/Registration/HealthCheckRegistration.cs
@@ -12,7 +12,7 @@ using static Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus;
 namespace Microsoft.Extensions.DependencyInjection;
 
 //To add other custom health checks, use AddCheck method and as a generic parameter pass a class that implements IHealthCheck interface
-public static class HealthCheckRegistration
+internal static class HealthCheckRegistration
 {
     private const string Basic = nameof(Basic);
     private const string Critical = nameof(Critical);

--- a/src/Shopway.Persistence/Registration/MediatorRegistration.cs
+++ b/src/Shopway.Persistence/Registration/MediatorRegistration.cs
@@ -3,7 +3,7 @@ using Shopway.Persistence.Pipelines;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class MediatorRegistration
+internal static class MediatorRegistration
 {
     internal static IServiceCollection RegisterMediator(this IServiceCollection services)
     {

--- a/src/Shopway.Persistence/Registration/RepositoriesRegistration.cs
+++ b/src/Shopway.Persistence/Registration/RepositoriesRegistration.cs
@@ -6,7 +6,7 @@ using Shopway.Persistence.Repositories;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class RepositoriesRegistration
+internal static class RepositoriesRegistration
 {
     internal static IServiceCollection RegisterRepositories(this IServiceCollection services)
     {

--- a/src/Shopway.Presentation/Registration/AuthenticationRegistration.cs
+++ b/src/Shopway.Presentation/Registration/AuthenticationRegistration.cs
@@ -6,7 +6,7 @@ using Shopway.Presentation.Authentication.RolePermissionAuthentication.Handlers;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class AuthenticationRegistration
+internal static class AuthenticationRegistration
 {
     internal static IServiceCollection RegisterAuthentication(this IServiceCollection services)
     {

--- a/src/Shopway.Presentation/Registration/ControllerRegistration.cs
+++ b/src/Shopway.Presentation/Registration/ControllerRegistration.cs
@@ -6,7 +6,7 @@ using ApiBehaviorOptions = Shopway.Presentation.Options.ApiBehaviorOptions;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class ControllerRegistration
+internal static class ControllerRegistration
 {
     internal static IServiceCollection RegisterControllers(this IServiceCollection services)
     {

--- a/src/Shopway.Presentation/Registration/CorsPolicyRegistration.cs
+++ b/src/Shopway.Presentation/Registration/CorsPolicyRegistration.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class CorsPolicyRegistration
+internal static class CorsPolicyRegistration
 {
     public static IApplicationBuilder UseCorsPolicy(this IApplicationBuilder app)
     {

--- a/src/Shopway.Presentation/Registration/OpenApiRegistration.cs
+++ b/src/Shopway.Presentation/Registration/OpenApiRegistration.cs
@@ -8,7 +8,7 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class OpenApiRegistration
+internal static class OpenApiRegistration
 {
     private const string SwaggerDarkThameStyleFileName = "SwaggerDark.css";
     private const string WwwRootDirectoryName = "OpenApi";

--- a/src/Shopway.Presentation/Registration/VersioningRegistration.cs
+++ b/src/Shopway.Presentation/Registration/VersioningRegistration.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class VersioningRegistration
+internal static class VersioningRegistration
 {
     private const string ApiVersionHeader = "api-version";
 


### PR DESCRIPTION
If the Registration class access modifier is public, this can lead to incorrect usage when methods with public access
Ex.
```cs
// the Registration class access modifier is `public`
public static class FluentValidationRegistration
{
    internal static IServiceCollection RegisterFluentValidation(this IServiceCollection services)
    {
        // ...
        return services;
    }

    // wrong: it can lead to incorrect usage
    public static IServiceCollection RegisterSomthing(this IServiceCollection services)
    {
        // ...
        return services;
    }     
}
``` 