### PR TITLE
refactor: change the 'operator ==' method parameter names to be more explicit

### DIFF
--- a/src/Shopway.Domain/Common/BaseTypes/Enumeration.cs
+++ b/src/Shopway.Domain/Common/BaseTypes/Enumeration.cs
@@ -51,24 +51,24 @@ public abstract class Enumeration<TEnum> : IEquatable<Enumeration<TEnum>>, IComp
     /// </summary>
     public string Name { get; protected init; }
 
-    public static bool operator ==(Enumeration<TEnum>? a, Enumeration<TEnum>? b)
+    public static bool operator ==(Enumeration<TEnum>? first, Enumeration<TEnum>? second)
     {
-        if (a is null && b is null)
+        if (first is null && second is null)
         {
             return true;
         }
 
-        if (a is null || b is null)
+        if (first is null || second is null)
         {
             return false;
         }
 
-        return a.Equals(b);
+        return first.Equals(second);
     }
 
-    public static bool operator !=(Enumeration<TEnum> a, Enumeration<TEnum> b)
+    public static bool operator !=(Enumeration<TEnum> first, Enumeration<TEnum> second)
     {
-        return !(a == b);
+        return !(first == second);
     }
 
     /// <summary>

--- a/src/Shopway.Domain/Common/Errors/Error.cs
+++ b/src/Shopway.Domain/Common/Errors/Error.cs
@@ -71,24 +71,24 @@ public sealed partial class Error : IEquatable<Error>
         return error.Code;
     }
 
-    public static bool operator ==(Error? a, Error? b)
+    public static bool operator ==(Error? first, Error? second)
     {
-        if (a is null && b is null)
+        if (first is null && second is null)
         {
             return true;
         }
 
-        if (a is null || b is null)
+        if (first is null || second is null)
         {
             return false;
         }
 
-        return a.Equals(b);
+        return first.Equals(second);
     }
 
-    public static bool operator !=(Error? a, Error? b)
+    public static bool operator !=(Error? first, Error? second)
     {
-        return !(a == b);
+        return !(first == second);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
`a`, `b` parameter names are implicit.

### After
```
public static bool operator ==(Error? a, Error? b)
```
### Before
```
public static bool operator ==(Error? first, Error? second)
```