### PR TITLE
fix: change invalid assembly reference

### DIFF
--- a/test/Shopway.Tests.Unit/ArchitectureTests/NamingConventions/NamingConventionsTests.Jobs.cs
+++ b/test/Shopway.Tests.Unit/ArchitectureTests/NamingConventions/NamingConventionsTests.Jobs.cs
@@ -12,7 +12,7 @@ public partial class NamingConventionsTests
     public void JobNames_ShouldEndWithJob()
     {
         //Arrange
-        var assembly = Shopway.Infrastructure.AssemblyReference.Assembly;
+        var assembly = Shopway.Persistence.AssemblyReference.Assembly;
 
         //Act
         var result = Types


### PR DESCRIPTION
The `IJob` interface is implemented only in the persistence assembly.